### PR TITLE
Change "Total"/"Formatted" capacity to GB/GiB

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,8 @@
 	        	<div class="card">
 				 	<div class="card-body">
 				 		<h5 class="card-title">Capacity</h5>
-				    	<span id="gbCapacityResult" class="card-text">--</span> /
-				    	<span id="gibCapacityResult" class="card-text">--</span>
+				    	<span id="gbCapacityResult" class="card-text">--</span> GB /
+				    	<span id="gibCapacityResult" class="card-text">--</span> GiB
 				  	</div>
 				</div>
 				<br>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         <div class="mt-1">
             <h1>Natho's Raid Calculator</h1>
         </div>
-        <p class="lead">Calculate total and formatted disk space with raid.</p>
+        <p class="lead">Calculate disk space in GB and GiB with RAID.</p>
         <div class="row">
         	<div class="col-sm-6">
 	        	<form>
@@ -41,22 +41,16 @@
 	        <div class="col-sm-6">
 	        	<div class="card">
 				 	<div class="card-body">
-				 		<h5 class="card-title">Total Capacity</h5>
-				    	<p id="totalCapacityResult" class="card-text">--</p>
-				  	</div>
-				</div>
-				<br>
-				<div class="card">
-				 	<div class="card-body">
-				 		<h5 class="card-title">Formatted Capacity</h5>
-				    	<p id="formattedCapacityResult" class="card-text">--</p>
+				 		<h5 class="card-title">Capacity</h5>
+				    	<span id="gbCapacityResult" class="card-text">--</span> /
+				    	<span id="gibCapacityResult" class="card-text">--</span>
 				  	</div>
 				</div>
 				<br>
 				<div class="card">
 				 	<div class="card-body">
 				 		<h5 class="card-title">Fault Tolerance</h5>
-				    	<p id="toleranceResult" class="card-text">--</p>
+				    	<span id="toleranceResult" class="card-text">--</span>
 				  	</div>
 				</div>
 	        </div>

--- a/script.js
+++ b/script.js
@@ -50,8 +50,8 @@ function test(disks, capacity, type) {
 }
 
 function setResults(gb, gib, tolerance) {
-	$("#gbCapacityResult").text(gb + ' GB')
-	$("#gibCapacityResult").text(gib + ' GiB')
+	$("#gbCapacityResult").text(gb)
+	$("#gibCapacityResult").text(gib)
 	$("#toleranceResult").text(tolerance + ' Drive Failure' + (tolerance == 1 ? '':'s'))
 }
 

--- a/script.js
+++ b/script.js
@@ -25,7 +25,7 @@ function calculateCapacity(n, c, t) {
 	return e * (n * c)
 }
 
-function convertToFormatted(capacity) {
+function convertToGib(capacity) {
 	return capacity * 0.931
 }
 
@@ -49,15 +49,15 @@ function test(disks, capacity, type) {
 	return true;
 }
 
-function setResults(total, formatted, tolerance) {
-	$("#totalCapacityResult").text(total + ' GB')
-	$("#formattedCapacityResult").text(formatted + ' GB')
+function setResults(gb, gib, tolerance) {
+	$("#gbCapacityResult").text(gb + ' GB')
+	$("#gibCapacityResult").text(gib + ' GiB')
 	$("#toleranceResult").text(tolerance + ' Drive Failure' + (tolerance == 1 ? '':'s'))
 }
 
 function clearResults() {
-	$("#totalCapacityResult").text('--')
-	$("#formattedCapacityResult").text('--')
+	$("#gbCapacityResult").text('--')
+	$("#gibCapacityResult").text('--')
 	$("#toleranceResult").text('--')
 }
 
@@ -74,8 +74,8 @@ function trigger() {
 		return console.log(result)
 	}	
 
-	var total = Math.floor(calculateCapacity(disks, capacity, type))
-	var formatted = Math.floor(convertToFormatted(total))
+	var gb = Math.floor(calculateCapacity(disks, capacity, type))
+	var gib = Math.floor(convertToGib(gb))
 
 	var tolerance = 0
 	switch (type) {
@@ -101,7 +101,7 @@ function trigger() {
 			break
 	}
 
-	setResults(total, formatted, tolerance)
+	setResults(gb, gib, tolerance)
 }
 
 $(":text").keyup(function() {


### PR DESCRIPTION
Formatted capacity isn't actually a thing in this scenario. It's just what drive manufacturers say to avoid having to explain why your 1TB drive is missing 69GB.

I also changed 'raid' to 'RAID', and moved the GB/GiB labels from JS so that when the input is invalid, "-- GB / -- GiB" is shown, rather than "-- / --".